### PR TITLE
Fixed wrong operation ID on the character-species endpointttt

### DIFF
--- a/IGDB-OpenAPI.json
+++ b/IGDB-OpenAPI.json
@@ -572,7 +572,7 @@
             }
           }
         },
-        "operationId": "RetreiveCharacterGenders",
+        "operationId": "RetreiveCharacterSpecies",
         "responses": {
           "200": {
             "description": "Success",

--- a/IGDB-OpenAPI.yaml
+++ b/IGDB-OpenAPI.yaml
@@ -372,7 +372,7 @@ paths:
             schema:
               type: string
             example: fields checksum,created_at,name,updated_at;'
-      operationId: RetreiveCharacterGenders
+      operationId: RetreiveCharacterSpecies
       responses:
         "200":
           description: Success


### PR DESCRIPTION
Fixed wrong operation ID on the character-species endpoint, which led to a semantic error (duplicate operation IDs) in code generation.