### PR TITLE
Fix YAML to work with Java

### DIFF
--- a/IGDB-OpenAPI.yaml
+++ b/IGDB-OpenAPI.yaml
@@ -2920,7 +2920,7 @@ components:
         - ESRB_mild_sexual_themes
         - ESRB_use_of_alcohol_and_tobacco
         - ESRB_animated_blood_and_gore
-        - ESRB_mild_fantasy violence
+        - ESRB_mild_fantasy_violence
         - ESRB_mild_lyrics
         - ESRB_realistic_blood
         - PEGI_violence
@@ -2940,7 +2940,7 @@ components:
         - CERO_gambling
         - CERO_crime
         - CERO_controlled_substances
-        - CERO_languages_and others
+        - CERO_languages_and_others
         - GRAC_sexuality
         - GRAC_violence
         - GRAC_fear_horror_threatening
@@ -4803,8 +4803,8 @@ components:
       format: int32
       enum: [0, 1]
       x-enum-varnames:
-        - boolean
-        - description
+        - BOOLEAN
+        - DESCRIPTION
       x-enum-descriptions:
         - 'boolean'
         - 'description'


### PR DESCRIPTION
Fix the IGDB-OpenAPI.yaml to work with Java generator

* Fix enum with spaces causing a Java compilation error
* Fix enum with reserved `boolean` Java keyword causing a compilation error

May want to also apply these changes to JSON file.